### PR TITLE
fix(auth): when using multiple auth methods use @aws_cognito_user_pools directive

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -12,7 +12,7 @@ type Mutation {
   @aws_api_key
 
   addUser(input: UserInput!): Boolean
-  @aws_auth(cognito_groups: ["Admin"])
+  @aws_cognito_user_pools(cognito_groups: ["Admin"])
 }
 
 type UsersPage {


### PR DESCRIPTION
If that's not the case, users in `Users` group will be able to create users when only the ones in `Admin` group should.